### PR TITLE
Set timestamp in move constructor of shar::Packer. Fix packetizer "MTU overrun" bug.

### DIFF
--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -18,6 +18,8 @@ public:
     sinks.push_back(std::make_shared<spdlog::sinks::simple_file_sink_mt>(file_path));
     sinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
     m_logger = std::make_shared<spdlog::logger>("shar", sinks.begin(), sinks.end());
+    // TODO: make configurable
+    m_logger->set_level(spdlog::level::debug);
     m_logger->set_pattern("[%D %T] [%n] %v");
     spdlog::register_logger(m_logger);
     m_logger->info("Logger has been initialized");

--- a/src/encoder/ffmpeg/codec.cpp
+++ b/src/encoder/ffmpeg/codec.cpp
@@ -39,6 +39,9 @@ Codec::Codec(Size frame_size, std::size_t fps, Logger logger, const ConfigPtr& c
 }
 
 std::vector<Packet> Codec::encode(const shar::Frame& image) {
+  assert(m_context.get()->width == image.width());
+  assert(m_context.get()->height == image.height());
+
   auto[y, u, v] = bgra_to_yuv420(image);
 
   AVFrame* frame = av_frame_alloc();

--- a/src/network/fragment.cpp
+++ b/src/network/fragment.cpp
@@ -105,6 +105,11 @@ std::uint8_t* Fragment::payload() noexcept {
   return m_data + MIN_SIZE;
 }
 
+const std::uint8_t* Fragment::payload() const noexcept {
+  assert(valid());
+  return m_data + MIN_SIZE;
+}
+
 std::size_t Fragment::payload_size() const noexcept {
   return size() - MIN_SIZE;
 }

--- a/src/network/fragment.hpp
+++ b/src/network/fragment.hpp
@@ -101,6 +101,7 @@ public:
 
   // payload - returns pointer to start of payload
   std::uint8_t* payload() noexcept;
+  const std::uint8_t* payload() const noexcept;
   std::size_t payload_size() const noexcept;
 
 private:

--- a/src/network/packet.cpp
+++ b/src/network/packet.cpp
@@ -19,19 +19,23 @@ Packet::Packet(std::unique_ptr<std::uint8_t[]> data, std::size_t size, std::uint
 Packet::Packet(Packet&& from) noexcept
     : m_bytes(std::move(from.m_bytes))
     , m_size(from.m_size)
+    , m_timestamp(from.m_timestamp)
     , m_type(from.m_type) {
   from.m_size = 0;
+  from.m_timestamp = 0;
   from.m_type = Type::Unknown;
 }
 
 Packet& Packet::operator=(Packet&& from) noexcept {
   if (this != &from) {
     m_bytes = std::move(from.m_bytes);
-    m_size  = from.m_size;
-    m_type  = from.m_type;
+    m_size = from.m_size;
+    m_timestamp = from.m_timestamp;
+    m_type = from.m_type;
 
-    from.m_type = Type::Unknown;
     from.m_size = 0;
+    from.m_type = Type::Unknown;
+    from.m_timestamp = 0;
   }
   return *this;
 }

--- a/src/network/packet.hpp
+++ b/src/network/packet.hpp
@@ -18,7 +18,7 @@ public:
 
   // moves ownership over |data| to packet
   Packet(void* data, std::size_t size);
-  Packet(std::unique_ptr<std::uint8_t[]> data, std::size_t size, std::uint32_t timestamp,Type type=Type::Unknown);
+  Packet(std::unique_ptr<std::uint8_t[]> data, std::size_t size, std::uint32_t timestamp, Type type=Type::Unknown);
 
   Packet(const Packet&) = delete;
   Packet(Packet&&) noexcept;

--- a/src/network/packetizer.cpp
+++ b/src/network/packetizer.cpp
@@ -67,9 +67,9 @@ Fragment Packetizer::next() noexcept {
   // for following fragments:
   //
   // 0x00 0x00 0x00 0xff 0xff 0xff ... 0xff 0xff 0xff 0xff 0xff 0xff
-  // |  prefix bytes  |   |   |____________|  |
+  // |  prefix bytes  |   |   |___________|  |
   //                 /    |         |       'start' points here
-  //   was 0x01 byte,     |    previous fragments
+  //   was 0x01 byte,     |   previous fragments
   //   now indicator      |
   //                 'm_nal_start', header is stored here
   //

--- a/src/network/packetizer.cpp
+++ b/src/network/packetizer.cpp
@@ -87,8 +87,8 @@ Fragment Packetizer::next() noexcept {
 
     if (first == 1) {
       // from RFC6184: Start bit and End bit MUST NOT both be set
-			//               to one in the same FU header
-			// ... so we have to generate entire (though empty) packet just for end flag
+      //               to one in the same FU header
+      // ... so we have to generate entire (though empty) packet just for end flag
       m_last_packet_full_nal_unit = true;
     } else {
       last = 1;

--- a/src/network/packetizer.cpp
+++ b/src/network/packetizer.cpp
@@ -73,8 +73,8 @@ Fragment Packetizer::next() noexcept {
   //   now indicator      |
   //                 'm_nal_start', header is stored here
   //
-  // ...with that covered, it is up to reader to realize the
-  //  reasons behind magic constants in code below
+  // ...with that covered, it is up to reader to understand the
+  //  reasons behind magic offsets in code below
   std::uint8_t first = start == m_nal_start ? 1 : 0;
   std::uint8_t nri = *(m_nal_start - 1 + first) & Fragment::NRI_MASK;
   std::uint8_t nal_type = *m_nal_start & Fragment::NAL_TYPE_MASK;

--- a/src/network/packetizer.hpp
+++ b/src/network/packetizer.hpp
@@ -28,8 +28,8 @@ public:
 private:
   bool valid() const noexcept;
 
-  // returns (nullptr, nullptr) if no more fragments
-  std::pair<std::uint8_t*, std::uint8_t*> next_fragment() noexcept;
+  // returns nullptr if there are no more fragments
+  std::uint8_t* next_fragment() noexcept;
 
   // returns true on success
   bool next_nal() noexcept;

--- a/src/network/tests/packetizer.cpp
+++ b/src/network/tests/packetizer.cpp
@@ -113,7 +113,7 @@ TEST(packetizer, big_units) {
   auto fragment = packetizer.next();
   ASSERT_TRUE(fragment.valid());
 
-  EXPECT_EQ(fragment.size(), 6);
+  EXPECT_EQ(fragment.size(), 4);
 
   EXPECT_EQ(fragment.nri(), 3);
   EXPECT_EQ(fragment.packet_type(), 28);
@@ -122,17 +122,49 @@ TEST(packetizer, big_units) {
   EXPECT_FALSE(fragment.is_last());
   EXPECT_EQ(fragment.nal_type(), 7);
 
-  EXPECT_EQ(fragment.payload_size(), 4);
+  EXPECT_EQ(fragment.payload_size(), 2);
   EXPECT_EQ(fragment.payload()[0], 0x42);
   EXPECT_EQ(fragment.payload()[1], 0x00);
-  EXPECT_EQ(fragment.payload()[2], 0x20);
-  EXPECT_EQ(fragment.payload()[3], 0xe9);
 
   // second fragment (same nal)
   fragment = packetizer.next();
   ASSERT_TRUE(fragment.valid());
 
-  EXPECT_EQ(fragment.size(), 6);
+  EXPECT_EQ(fragment.size(), 4);
+
+  EXPECT_EQ(fragment.nri(), 3);
+  EXPECT_EQ(fragment.packet_type(), 28);
+
+  EXPECT_FALSE(fragment.is_first());
+  EXPECT_FALSE(fragment.is_last());
+  EXPECT_EQ(fragment.nal_type(), 7);
+
+  EXPECT_EQ(fragment.payload_size(), 2);
+  EXPECT_EQ(fragment.payload()[0], 0x20);
+  EXPECT_EQ(fragment.payload()[1], 0xe9);
+
+  // third fragment
+  fragment = packetizer.next();
+  ASSERT_TRUE(fragment.valid());
+
+  EXPECT_EQ(fragment.size(), 4);
+
+  EXPECT_EQ(fragment.nri(), 3);
+  EXPECT_EQ(fragment.packet_type(), 28);
+
+  EXPECT_FALSE(fragment.is_first());
+  EXPECT_FALSE(fragment.is_last());
+  EXPECT_EQ(fragment.nal_type(), 7);
+
+  EXPECT_EQ(fragment.payload_size(), 2);
+  EXPECT_EQ(fragment.payload()[0], 0x00);
+  EXPECT_EQ(fragment.payload()[1], 0x80);
+
+  // fourth fragment
+  fragment = packetizer.next();
+  ASSERT_TRUE(fragment.valid());
+
+  EXPECT_EQ(fragment.size(), 4);
 
   EXPECT_EQ(fragment.nri(), 3);
   EXPECT_EQ(fragment.packet_type(), 28);
@@ -141,11 +173,9 @@ TEST(packetizer, big_units) {
   EXPECT_TRUE(fragment.is_last());
   EXPECT_EQ(fragment.nal_type(), 7);
 
-  EXPECT_EQ(fragment.payload_size(), 4);
-  EXPECT_EQ(fragment.payload()[0], 0x00);
-  EXPECT_EQ(fragment.payload()[1], 0x80);
-  EXPECT_EQ(fragment.payload()[2], 0x0c);
-  EXPECT_EQ(fragment.payload()[3], 0x32);
+  EXPECT_EQ(fragment.payload_size(), 2);
+  EXPECT_EQ(fragment.payload()[0], 0x0c);
+  EXPECT_EQ(fragment.payload()[1], 0x32);
 
   ASSERT_FALSE(packetizer.next().valid());
 }


### PR DESCRIPTION
Closes #102 