### PR TITLE
Logs improvements

### DIFF
--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -1,12 +1,13 @@
 #include "app.hpp"
 
 #include <thread>
-#include <chrono>
+#include <filesystem>
 
 #include "disable_warnings_push.hpp"
 #include <SDL2/SDL_events.h>
 #include "disable_warnings_pop.hpp"
 
+#include "time.hpp"
 #include "size.hpp"
 #include "ui/gl_vtable.hpp"
 #include "ui/nk.hpp"
@@ -14,14 +15,29 @@
 
 namespace shar {
 
+namespace fs = std::filesystem;
+
 static Context make_context(Options options) {
   auto config = std::make_shared<Options>(std::move(options));
-  auto shar_loglvl = config->loglvl;
-  if (shar_loglvl > config->encoder_loglvl) {
+  auto shar_loglvl = config->log_level;
+  if (shar_loglvl > config->encoder_log_level) {
     throw std::runtime_error("Encoder log level be less than general log level");
   }
 
-  auto logger = Logger(config->log_file, shar_loglvl);
+  if (config->log_level != LogLevel::None) {
+    auto status = fs::status(config->logs_location);
+    if (!fs::exists(status)) {
+      if (!fs::create_directories(config->logs_location)) {
+        throw std::runtime_error("Failed to create logs directory");
+      }
+    }
+    else if (!fs::is_directory(status)) {
+      throw std::runtime_error("logs_location parameter should point to a directory");
+    }
+  }
+
+  // TODO: check that logs location exists
+  auto logger = Logger(config->logs_location, shar_loglvl);
   auto registry = std::make_shared<metrics::Registry>();
 
   return Context{
@@ -251,7 +267,7 @@ int App::run() {
     }
 
     render();
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    std::this_thread::sleep_for(Milliseconds(5));
   }
 
   return EXIT_SUCCESS;

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -36,7 +36,6 @@ static Context make_context(Options options) {
     }
   }
 
-  // TODO: check that logs location exists
   auto logger = Logger(config->logs_location, shar_loglvl);
   auto registry = std::make_shared<metrics::Registry>();
 

--- a/src/codec/ffmpeg/codec.cpp
+++ b/src/codec/ffmpeg/codec.cpp
@@ -57,7 +57,7 @@ static void setup_logging(const shar::OptionsPtr& config, shar::Logger& logger) 
 
   const auto log_level_to_ffmpeg = [](LogLevel level) {
     switch (level) {
-      case LogLevel::Quiet:
+      case LogLevel::None:
         return AV_LOG_QUIET;
       case LogLevel::Trace:
         return AV_LOG_TRACE;
@@ -76,7 +76,7 @@ static void setup_logging(const shar::OptionsPtr& config, shar::Logger& logger) 
     }
   };
 
-  av_log_set_level(log_level_to_ffmpeg(config->encoder_loglvl));
+  av_log_set_level(log_level_to_ffmpeg(config->encoder_log_level));
   av_log_set_callback(avlog_callback);
 }
 

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -5,6 +5,8 @@ add_library(common
             context.hpp
             channel.hpp
             size.hpp
+            time.hpp
+            time.cpp
             disable_warnings_push.hpp
             disable_warnings_pop.hpp
             cancellation.hpp

--- a/src/common/logger.hpp
+++ b/src/common/logger.hpp
@@ -1,15 +1,19 @@
 #pragma once
 
-#include <string>
+#include <filesystem>
 #include <cstring>
 #include <map>
 #include <memory>
 
 #include "disable_warnings_push.hpp"
-#include "spdlog/logger.h"
-#include "spdlog/spdlog.h"
+#include <spdlog/logger.h>
+#include <spdlog/spdlog.h>
+#if defined(_MSC_VER) && defined(SHAR_DEBUG_BUILD)
+#include <spdlog/sinks/msvc_sink.h>
+#endif
 #include "disable_warnings_pop.hpp"
 
+#include "time.hpp"
 #include "options.hpp"
 
 
@@ -17,7 +21,8 @@ namespace shar {
 
 class Logger {
 public:
-  explicit Logger(const std::string& file_path, LogLevel loglvl) {
+  // TODO: move to cpp file
+  explicit Logger(const std::filesystem::path& location, LogLevel loglvl) {
     const auto log_level_to_spd = [](LogLevel level) {
       switch (level) {
       case LogLevel::Trace:
@@ -30,17 +35,26 @@ public:
         return spdlog::level::warn;
       case LogLevel::Error:
         return spdlog::level::critical;
-      case LogLevel::Quiet:
-        return spdlog::level::off;
       case LogLevel::Critical:
         return spdlog::level::critical;
+      case LogLevel::None:
+        return spdlog::level::off;
       default:
         throw std::runtime_error("Unknown log level");
       }
     };
 
     std::vector<spdlog::sink_ptr> sinks;
-    sinks.push_back(std::make_shared<spdlog::sinks::simple_file_sink_mt>(file_path));
+    if (loglvl != LogLevel::None) {
+      auto time = to_string(SystemClock::now());
+      auto file_path = location / (fmt::format("shar_{}.log", time));
+      sinks.emplace_back(std::make_shared<spdlog::sinks::simple_file_sink_mt>(file_path.string()));
+    }
+
+#if defined(_MSC_VER) && defined(SHAR_DEBUG_BUILD)
+    sinks.emplace_back(std::make_shared<spdlog::sinks::msvc_sink_mt>());
+#endif
+
     // TODO: add custom GUI-based sink
     m_logger = std::make_shared<spdlog::logger>("shar", sinks.begin(), sinks.end());
     m_logger->set_level(log_level_to_spd(loglvl));

--- a/src/common/options.hpp
+++ b/src/common/options.hpp
@@ -7,8 +7,15 @@
 
 namespace shar {
 
+#ifdef SHAR_DEBUG_BUILD
+#define DEFAULT_LOG_LEVEL LogLevel::Debug
+#else
+#define DEFAULT_LOG_LEVEL LogLevel::None
+#endif
+
+
 enum class LogLevel {
-  Quiet,
+  None,
   Trace,
   Debug,
   Info,
@@ -29,9 +36,10 @@ struct Options {
   std::string codec;                                 // which codec to use
   std::size_t bitrate{ 5000 };                       // target bitrate (in kbits)
   std::string metrics{ "127.0.0.1:3228" };           // where to expose metrics
-  LogLevel loglvl{ LogLevel::Info };                 // loglvl for shar logger
-  std::string log_file{ "shar.log" };                // name of logfile
-  LogLevel encoder_loglvl{ LogLevel::Critical };     // loglvl for encoder logger
+  LogLevel log_level{ DEFAULT_LOG_LEVEL };           // common log level
+  std::string logs_location{ "" };                   // logs location, set to ~/.shar/logs
+                                                     // by default
+  LogLevel encoder_log_level{ DEFAULT_LOG_LEVEL };   // log level for encoder
   using Option = std::pair<std::string, std::string>;// name -> value
   std::vector<Option> options{                       // options for codec
     {"preset", "medium"},

--- a/src/common/time.cpp
+++ b/src/common/time.cpp
@@ -1,0 +1,22 @@
+#include "time.hpp"
+
+#include <ctime>
+
+
+namespace shar {
+
+std::string to_string(SystemTime system_time) {
+  std::time_t t = SystemClock::to_time_t(system_time);
+
+  char buffer[20] = { 0 };
+  if (std::tm* time = std::localtime(&t)) {
+    std::strftime(buffer, 20, "%Y-%m-%d_%H-%M-%S", std::localtime(&t));
+  }
+  else {
+    return "<invalid time>";
+  }
+
+  return std::string(buffer);
+}
+
+}

--- a/src/common/time.hpp
+++ b/src/common/time.hpp
@@ -1,12 +1,19 @@
 #pragma once
 
 #include <chrono>
+#include <string>
 
 
 namespace shar {
 
 using Clock = std::chrono::high_resolution_clock;
 using TimePoint = Clock::time_point;
+
+using SystemClock = std::chrono::system_clock;
+using SystemTime = SystemClock::time_point;
+
 using Milliseconds = std::chrono::milliseconds;
+
+std::string to_string(SystemTime time);
 
 }

--- a/src/ui/renderer.cpp
+++ b/src/ui/renderer.cpp
@@ -20,7 +20,7 @@
 #define SHAR_SHADER_VERSION "#version 300 es\n"
 #endif
 
-
+#ifdef SHAR_DEBUG_BUILD
 static void GLAPIENTRY opengl_error_callback(
   GLenum /*source*/,
   GLenum type,
@@ -36,6 +36,7 @@ static void GLAPIENTRY opengl_error_callback(
     << ", message = " << message
     << std::endl;
 }
+#endif
 
 namespace shar::ui {
 
@@ -73,12 +74,15 @@ Renderer::~Renderer() {
 }
 
 void Renderer::init() {
+
+#ifdef SHAR_DEBUG_BUILD
   // opengl debug output
   if (void* ptr = SDL_GL_GetProcAddress("glDebugMessageCallback")) {
     glEnable(GL_DEBUG_OUTPUT);
     auto debug_output = (PFNGLDEBUGMESSAGECALLBACKARBPROC)ptr;
     debug_output(opengl_error_callback, nullptr);
   }
+#endif
 
   // TODO: remove after migration to CORE OpenGL profile
   glEnable(GL_TEXTURE_2D);


### PR DESCRIPTION
- Use system time as suffix for log file
- Store log files in "~/.shar/logs" by default 
- Disable logging by default in release builds.
- Disable OpenGL debug output in release builds

Closes #159