### PR TITLE
fix for macos build 

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,7 +4,7 @@ from conans import ConanFile, CMake
 class Shar(ConanFile):
     settings        = "os",  "compiler",  "build_type"
 
-    requires        = ("asio/1.12.0@bincrafters/stable",              # network
+    requires        = ("asio/1.16.1",                                 # network
                        "ScreenCaptureLite/16.1.0@0xd34d10cc/testing", # capture
                        "ffmpeg/4.0@0xd34d10cc/testing",               # encoder
                        "sdl2/2.0.9@bincrafters/stable",               # window, input, OpenGL

--- a/src/ui/texture.cpp
+++ b/src/ui/texture.cpp
@@ -6,7 +6,11 @@
 #include <windows.h>
 #endif
 
+#ifdef __APPLE__
+#include <OpenGL/gl.h>
+#else
 #include <GL/gl.h>
+#endif
 #include "disable_warnings_pop.hpp"
 
 


### PR DESCRIPTION
Change version for asio to avoid problems with apple clang and boost's string_view, and patch path to Gl.h special for macOS